### PR TITLE
Added keyboard support

### DIFF
--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -42,7 +42,7 @@ function init() {
     synthesizer.bbox.centerX = 0;
     synthesizer.bbox.minY = visibleRect.max.y;
     synthesizer.bbox.centerZ = 0;
-    synthesizer.addMouseListener(renderer, camera);
+    synthesizer.addInputListener(renderer, camera);
     scene.add(synthesizer);
   });
 }


### PR DESCRIPTION
A really quick pass on keyboard support. Uses shift for black keys.
The mapping is as follows, the index of the `event.key` from an `onKeyDown` event in the following array corresponds to the index of the key in `this.keys`:

```javascript
const keyboardKeyMap = [
  'q', 'Q', 'w', 'W', 'e', 'r', 'R', 't', 'T', 'y', 'Y', 'u', 'i', 'I', 'o', 'O', 'p', 
  'a', 'A', 's', 'S', 'd', 'D', 'f', 'g', 'G', 'h', 'H', 'j', 'k', 'K', 'l', 'L',
  'z', 'Z', 'x', 'c', 'C', 'v', 'V', 'b', 'n', 'N', 'm', 'M', ',', '!', '.'
];
```